### PR TITLE
Allow for array result for action handler

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -57,7 +57,7 @@ interface ActionCore {
 		context: any,
 		card: Contract,
 		request: any,
-	) => Promise<null | ContractSummary>;
+	) => Promise<null | ContractSummary | ContractSummary[]>;
 }
 
 interface Action extends ActionCore {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Adding the option of returning an array from action handlers.
Needed for https://github.com/product-os/jellyfish-action-library/blob/master/lib/actions/action-increment-tag.js#L12:
```
const handler = async (session, context, card, request) => {
	const names = _.castArray(request.arguments.name)
	return Bluebird.map(names, async (item) => {
...
```