### PR TITLE
Update mixins interface to allow extra

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,9 +21,15 @@ export interface CoreMixins {
 	initialize: (card: ContractDefinition) => Contract;
 }
 
+export interface ExtraMixins {
+	[key: string]: any;
+}
+
+export interface Mixins extends CoreMixins, ExtraMixins {}
+
 export interface Contracts extends Map<Contract> {}
 
-export type ContractFileFn = (mixins: CoreMixins) => ContractDefinition;
+export type ContractFileFn = (mixins: Mixins) => ContractDefinition;
 
 export type ContractFile = ContractDefinition | ContractFileFn;
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Update `ContractFn` interface to allow mixins that include more than just `CoreMixins`.