### PR TITLE
Use a looser request type until we define ActionRequest better

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,6 @@ import type {
 	ContractDefinition,
 	ContractData,
 	Context,
-	ActionRequestContract,
 } from '@balena/jellyfish-types/build/core';
 
 export interface Map<T> {
@@ -71,19 +70,22 @@ export interface Integration<TData = ContractData> {
 
 export interface Integrations extends Map<Integration> {}
 
-type ActionPreFn = (
+export type ActionPreFn = (
 	session: string,
 	context: Context,
-	request: ActionRequestContract,
-) => Promise<void> | void;
+	request: any,
+) => Promise<any> | any;
 
+// TS-TODO: it's annoying that action-increment-tag returns an array of contract summaries
+// whereas all the other actions return either null or a single contract summary. Might be
+// better to standardize?
 interface ActionCore<TData = ContractData> {
 	handler: (
 		session: string,
 		context: Context,
 		card: Contract<TData>,
-		request: ActionRequestContract,
-	) => Promise<null | ContractSummary<TData>>;
+		request: any,
+	) => Promise<null | ContractSummary<TData> | Array<ContractSummary<TData>>>;
 }
 
 interface Action<TData = ContractData> extends ActionCore<TData> {


### PR DESCRIPTION
Also fixed the return types of the `pre` and `handler` functions.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>