### PR TITLE
Add optional options to translate function

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,16 +58,21 @@ export interface IntegrationResult<TData> {
 	card: ContractDefinition<TData>;
 }
 
+export interface SyncFunctionOptions {
+	actor: string;
+}
+
 export interface Integration<TData = ContractData> {
 	slug: string;
 	initialize: () => Promise<void>;
 	destroy: () => Promise<void>;
 	mirror: (
 		card: Contract<TData>,
-		options: any,
+		options: SyncFunctionOptions,
 	) => Promise<Array<IntegrationResult<TData>>>;
 	translate: (
 		event: IntegrationEvent,
+		options?: SyncFunctionOptions,
 	) => Promise<Array<IntegrationResult<TData>>>;
 }
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---
Found this issue while converting the Discourse integration to TypeScript.

- Create interface for options used by `mirror` and `translate` functions
- Add this as an optional parameter for `translate` function

References:
- https://github.com/product-os/jellyfish-sync/blob/master/lib/pipeline.ts#L32
- https://github.com/product-os/jellyfish-plugin-default/blob/master/lib/integrations/discourse.js#L1011