### PR TITLE
Fix integration types

### DIFF
--- a/lib/jellyfish-plugin.ts
+++ b/lib/jellyfish-plugin.ts
@@ -22,7 +22,7 @@ import type {
 	JellyfishPlugin,
 	PluginIdentity,
 	ContractFile,
-	Integration,
+	IntegrationClass,
 	JellyfishPluginOptions,
 	CoreMixins,
 } from './types';
@@ -56,7 +56,7 @@ export abstract class JellyfishPluginBase implements JellyfishPlugin {
 
 	private _cardFiles: ContractFile[];
 	private _mixins: ContractFiles;
-	private _integrations: Integration[];
+	private _integrations: IntegrationClass[];
 	private _actions: ActionFile[];
 
 	protected constructor(options: JellyfishPluginOptions) {
@@ -117,7 +117,7 @@ export abstract class JellyfishPluginBase implements JellyfishPlugin {
 	}
 
 	getSyncIntegrations(context: Context) {
-		return this.getSafeMap<Integration>(
+		return this.getSafeMap<IntegrationClass>(
 			context,
 			this._integrations,
 			'integrations',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,7 +63,6 @@ export interface SyncFunctionOptions {
 }
 
 export interface Integration<TData = ContractData> {
-	slug: string;
 	initialize: () => Promise<void>;
 	destroy: () => Promise<void>;
 	mirror: (
@@ -76,7 +75,7 @@ export interface Integration<TData = ContractData> {
 	) => Promise<Array<IntegrationResult<TData>>>;
 }
 
-export interface Integrations extends Map<Integration> {}
+export interface Integrations extends Map<IntegrationClass> {}
 
 export type ActionPreFn = (
 	session: string,
@@ -112,6 +111,24 @@ export interface PluginIdentity {
 	version: string;
 }
 
+export interface IntegrationClass {
+	slug: string;
+	isEventValid: (
+		token: any,
+		rawEvent: any,
+		headers: { [key: string]: string },
+		loggerContext: Context,
+	) => boolean;
+	whoami: (
+		loggerContext: Context,
+		credentials: any,
+		options: {
+			errors: any;
+		},
+	) => null | Promise<any>;
+	new (params: any): Integration;
+}
+
 export interface JellyfishPluginOptions {
 	slug: string;
 	name: string;
@@ -119,7 +136,7 @@ export interface JellyfishPluginOptions {
 	requires?: PluginIdentity[];
 	cards?: ContractFile[];
 	mixins?: ContractFiles;
-	integrations?: Integration[];
+	integrations?: IntegrationClass[];
 	actions?: ActionFile[];
 }
 

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -4,4 +4,4 @@
  * Proprietary and confidential.
  */
 
-export const INTERFACE_VERSION: string = '1.1.0';
+export const INTERFACE_VERSION: string = '2.0.0';

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -5,13 +5,14 @@
  */
 
 import _ from 'lodash';
-import type { Contract } from '@balena/jellyfish-types/build/core';
+import { Context, Contract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionFile,
 	JellyfishPluginBase,
 	ContractFile,
 	ContractFiles,
 	Integration,
+	IntegrationClass,
 	PluginIdentity,
 	JellyfishPluginConstructor,
 	JellyfishPluginOptions,
@@ -50,11 +51,22 @@ export const card2: Contract = {
 	version: '1.0.0',
 };
 
-class TestIntegration implements Integration {
-	slug: string;
+abstract class TestIntegration implements Integration {
+	static isEventValid(
+		_token: any,
+		_rawEvent: any,
+		_headers: { [key: string]: string },
+		_loggerContext: Context,
+	): boolean {
+		return true;
+	}
 
-	constructor(slug: string) {
-		this.slug = slug;
+	static whoami(
+		_loggerContext: Context,
+		_credentials: any,
+		_options: { errors: any },
+	): Promise<any> | null {
+		return null;
 	}
 
 	async initialize() {
@@ -74,8 +86,13 @@ class TestIntegration implements Integration {
 	}
 }
 
-export const integration1 = new TestIntegration('integration-1');
-export const integration2 = new TestIntegration('integration-2');
+export class TestIntegration1 extends TestIntegration {
+	static slug: string = 'integration-1';
+}
+
+export class TestIntegration2 extends TestIntegration {
+	static slug: string = 'integration-2';
+}
 
 interface TestJellyfishPluginOptions {
 	slug?: string;
@@ -85,7 +102,7 @@ interface TestJellyfishPluginOptions {
 	requires?: PluginIdentity[];
 	cards?: ContractFile[];
 	mixins?: ContractFiles;
-	integrations?: Integration[];
+	integrations?: IntegrationClass[];
 	actions?: ActionFile[];
 }
 

--- a/test/jellyfish-plugin.spec.ts
+++ b/test/jellyfish-plugin.spec.ts
@@ -11,8 +11,8 @@ import {
 	TestPluginFactory,
 	card1,
 	card2,
-	integration1,
-	integration2,
+	TestIntegration1,
+	TestIntegration2,
 	action1,
 	action2,
 	mixins,
@@ -139,8 +139,8 @@ describe('JellyfishPlugin', () => {
 		test('throws an exception if duplicate integration slugs are found', () => {
 			const plugin = new (TestPluginFactory({
 				integrations: [
-					integration1,
-					Object.assign({}, integration2, { slug: integration1.slug }),
+					TestIntegration1,
+					Object.assign({}, TestIntegration2, { slug: TestIntegration1.slug }),
 				],
 			}))();
 
@@ -153,14 +153,14 @@ describe('JellyfishPlugin', () => {
 
 		test('returns a dictionary of integrations keyed by slug', () => {
 			const plugin = new (TestPluginFactory({
-				integrations: [integration1, integration2],
+				integrations: [TestIntegration1, TestIntegration2],
 			}))();
 
 			const loadedIntegrations = plugin.getSyncIntegrations(context);
 
 			expect(loadedIntegrations).toEqual({
-				'integration-1': integration1,
-				'integration-2': integration2,
+				'integration-1': TestIntegration1,
+				'integration-2': TestIntegration2,
 			});
 		});
 	});

--- a/test/plugin-manager.spec.ts
+++ b/test/plugin-manager.spec.ts
@@ -11,8 +11,8 @@ import {
 	TestPluginFactory,
 	card1,
 	card2,
-	integration1,
-	integration2,
+	TestIntegration1,
+	TestIntegration2,
 	action1,
 	action2,
 	mixins,
@@ -238,13 +238,15 @@ describe('PluginManager', () => {
 					TestPluginFactory({
 						slug: 'test-plugin-1',
 						name: 'Test Plugin 1',
-						integrations: [integration1],
+						integrations: [TestIntegration1],
 					}),
 					TestPluginFactory({
 						slug: 'test-plugin-2',
 						name: 'Test Plugin 2',
 						integrations: [
-							Object.assign({}, integration2, { slug: integration1.slug }),
+							Object.assign({}, TestIntegration2, {
+								slug: TestIntegration1.slug,
+							}),
 						],
 					}),
 				],
@@ -263,12 +265,12 @@ describe('PluginManager', () => {
 				plugins: [
 					TestPluginFactory({
 						slug: 'test-plugin-1',
-						integrations: [integration1],
+						integrations: [TestIntegration1],
 					}),
 
 					TestPluginFactory({
 						slug: 'test-plugin-2',
-						integrations: [integration2],
+						integrations: [TestIntegration2],
 					}),
 				],
 			});
@@ -276,8 +278,8 @@ describe('PluginManager', () => {
 			const loadedIntegrations = pluginManager.getSyncIntegrations(context);
 
 			expect(loadedIntegrations).toEqual({
-				'integration-1': integration1,
-				'integration-2': integration2,
+				'integration-1': TestIntegration1,
+				'integration-2': TestIntegration2,
 			});
 		});
 	});


### PR DESCRIPTION
Plugins should take integration classes, not objects.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>